### PR TITLE
feat: add contribute skill for contribution workflow

### DIFF
--- a/.claude/skills/contribute/SKILL.md
+++ b/.claude/skills/contribute/SKILL.md
@@ -26,13 +26,13 @@ git remote add upstream https://github.com/CAprogs/coding-dojo-ia-x-data.git
 
 ## Etape 2 - Synchroniser avec upstream
 
-Récupère les dernières modifications du repo de Charles et mets à jour la branche `main` locale :
+Récupère les dernières modifications du repo de Charles et mets à jour la branche `lille` locale :
 
 ```bash
 git fetch upstream
-git checkout main
-git merge upstream/main
-git push origin main
+git checkout lille
+git merge upstream/lille
+git push origin lille
 ```
 
 ## Etape 3 - Récupérer l'issue
@@ -53,21 +53,29 @@ gh issue list --repo CAprogs/coding-dojo-ia-x-data --state open
 
 Demande au contributeur quelle issue il veut traiter.
 
-## Etape 4 - Créer la branche de travail
+## Etape 4 - S'assigner sur l'issue
 
-Crée une branche nommée d'après l'issue depuis `main` à jour :
+Assigne le contributeur sur l'issue pour signaler aux autres qu'il travaille dessus et éviter les doublons :
 
 ```bash
-git checkout -b issue-$issue main
+gh issue edit $issue --repo CAprogs/coding-dojo-ia-x-data --add-assignee @me
 ```
 
-## Etape 5 - Développement
+## Etape 5 - Créer la branche de travail
+
+Crée une branche nommée d'après l'issue depuis `lille` à jour :
+
+```bash
+git checkout -b issue-$issue lille
+```
+
+## Etape 6 - Développement
 
 Informe le contributeur qu'il peut maintenant travailler sur sa branche. Rappelle-lui de :
 - Faire des commits atomiques et clairs
 - Référencer l'issue dans les messages de commit (ex: `refs #$issue`)
 
-## Etape 6 - Pousser et créer la PR
+## Etape 7 - Pousser et créer la PR
 
 Une fois le travail terminé, pousse la branche sur le fork et crée une PR vers upstream :
 
@@ -80,7 +88,7 @@ Puis crée la PR avec `gh` :
 ```bash
 gh pr create --repo CAprogs/coding-dojo-ia-x-data \
   --head <user>:issue-$issue \
-  --base main \
+  --base lille \
   --title "<titre descriptif>" \
   --body "Closes CAprogs/coding-dojo-ia-x-data#$issue
 
@@ -93,7 +101,7 @@ gh pr create --repo CAprogs/coding-dojo-ia-x-data \
 
 Demande confirmation au contributeur avant de créer la PR.
 
-## Etape 7 - Suivi
+## Etape 8 - Suivi
 
 Informe le contributeur que :
 - La PR est en attente de review par les mainteneurs

--- a/.claude/skills/contribute/SKILL.md
+++ b/.claude/skills/contribute/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: contribute
+description: Guide et automatise le flux de contribution au repo (fork, sync, branche, PR). Utiliser quand un contributeur veut travailler sur une issue ou soumettre une PR.
+argument-hint: [issue-number]
+arguments: [issue]
+allowed-tools: Bash(git *) Bash(gh *)
+---
+
+# Flux de contribution
+
+Tu guides le contributeur dans le workflow de contribution au repo upstream `CAprogs/coding-dojo-ia-x-data`.
+
+## Etape 1 - Vérifier le setup
+
+Vérifie que le remote `upstream` pointe vers `CAprogs/coding-dojo-ia-x-data` :
+
+```bash
+git remote -v
+```
+
+Si `upstream` n'existe pas, ajoute-le :
+
+```bash
+git remote add upstream https://github.com/CAprogs/coding-dojo-ia-x-data.git
+```
+
+## Etape 2 - Synchroniser avec upstream
+
+Récupère les dernières modifications du repo de Charles et mets à jour la branche `main` locale :
+
+```bash
+git fetch upstream
+git checkout main
+git merge upstream/main
+git push origin main
+```
+
+## Etape 3 - Récupérer l'issue
+
+Si un numéro d'issue est fourni (`$issue`), récupère ses détails :
+
+```bash
+gh issue view $issue --repo CAprogs/coding-dojo-ia-x-data
+```
+
+Affiche un résumé de l'issue au contributeur (titre, description, labels, assignee).
+
+Si aucun numéro n'est fourni, liste les issues ouvertes disponibles :
+
+```bash
+gh issue list --repo CAprogs/coding-dojo-ia-x-data --state open
+```
+
+Demande au contributeur quelle issue il veut traiter.
+
+## Etape 4 - Créer la branche de travail
+
+Crée une branche nommée d'après l'issue depuis `main` à jour :
+
+```bash
+git checkout -b issue-$issue main
+```
+
+## Etape 5 - Développement
+
+Informe le contributeur qu'il peut maintenant travailler sur sa branche. Rappelle-lui de :
+- Faire des commits atomiques et clairs
+- Référencer l'issue dans les messages de commit (ex: `refs #$issue`)
+
+## Etape 6 - Pousser et créer la PR
+
+Une fois le travail terminé, pousse la branche sur le fork et crée une PR vers upstream :
+
+```bash
+git push origin issue-$issue
+```
+
+Puis crée la PR avec `gh` :
+
+```bash
+gh pr create --repo CAprogs/coding-dojo-ia-x-data \
+  --head <user>:issue-$issue \
+  --base main \
+  --title "<titre descriptif>" \
+  --body "Closes CAprogs/coding-dojo-ia-x-data#$issue
+
+## Résumé
+<description des changements>
+
+## Tests
+<comment tester>"
+```
+
+Demande confirmation au contributeur avant de créer la PR.
+
+## Etape 7 - Suivi
+
+Informe le contributeur que :
+- La PR est en attente de review par les mainteneurs
+- Il peut suivre l'état de la PR avec `gh pr status`
+- Après merge, il devra resynchroniser son fork (reprendre à l'étape 2)


### PR DESCRIPTION
## Summary
- Ajout d'un skill Claude Code `/contribute` qui guide et automatise le flux de contribution au repo
- Le skill couvre tout le workflow : vérification du setup, sync avec upstream, récupération d'issue, création de branche, push et création de PR
- Utilisable avec `/contribute <issue-number>` ou `/contribute` pour lister les issues ouvertes

## Test plan
- [ ] Vérifier que `/contribute` liste les issues ouvertes du repo upstream
- [ ] Vérifier que `/contribute 12` récupère les détails de l'issue #12 et guide le workflow complet
- [ ] Vérifier que le remote upstream est correctement détecté/ajouté

🤖 Generated with [Claude Code](https://claude.com/claude-code)