### PR TITLE
docs: add data exploration workflow to CLAUDE.md

### DIFF
--- a/.claude/skills/check-contribution/SKILL.md
+++ b/.claude/skills/check-contribution/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: check-contribution
+description: >
+  Lance une revue complète pré-contribution selon les bonnes pratiques GitHub et les conventions
+  du dépôt. Déclencher quand l'utilisateur demande à vérifier, relire ou valider sa contribution,
+  ses commits ou sa branche avant d'ouvrir une pull request. Également sur les formulations
+  "je suis prêt à faire une PR ?", "vérifie mon travail", "valide mes changements", "revue avant merge".
+---
+
+# check-contribution
+
+Tu joues le rôle d'un ingénieur senior effectuant une revue pré-contribution. Exécute les vérifications suivantes dans l'ordre et produis un rapport structuré PASS/FAIL à la fin. Corrige les problèmes automatiquement quand c'est possible ; demande confirmation avant toute action destructive.
+
+---
+
+## 1. Nommage de la branche
+
+Commande : `git rev-parse --abbrev-ref HEAD`
+
+Le nom de branche doit commencer par l'un de ces préfixes : `feature/`, `fix/`, `bugfix/`, `hotfix/`, `chore/`, `docs/`, `refactor/`, `test/`, `ci/`, `perf/`.
+
+- PASS : la branche respecte la convention.
+- FAIL : indiquer le nom de branche et le pattern attendu. Ne PAS renommer la branche automatiquement — demander à l'utilisateur.
+
+---
+
+## 2. Messages de commit
+
+Commande : `git log origin/lille..HEAD --format="%H %s"` (ou `origin/main..HEAD` si sur main).
+
+Chaque sujet de commit doit suivre les **Conventional Commits** (imposé par commitizen dans ce dépôt) :
+
+```
+<type>[scope optionnel]: <description>
+```
+
+Types valides : `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+
+Règles :
+- Sujet ≤ 72 caractères.
+- Mode impératif, sans point final.
+- Pas de commits avec `WIP`, `tmp`, `TODO`, `fixup!`, `squash!` dans le sujet (ils doivent être squashés avant le merge).
+
+Pour chaque commit non conforme, afficher le hash + sujet et la règle violée. Proposer de reformuler interactivement avec `git rebase -i`.
+
+---
+
+## 3. Changements stagés / non stagés
+
+Commandes : `git status --short` et `git diff --stat`.
+
+- FAIL s'il y a des changements non commités appartenant à la feature (rappeler à l'utilisateur de commiter ou stasher).
+- WARN s'il y a des fichiers non trackés qui ressemblent à du code source (`.py`, `.sql`, `.yml`, `.toml`, `.md`).
+
+---
+
+## 4. Qualité du code — Python
+
+Commande : `just lint` (qui exécute ruff check + ruff format --check + mypy).
+
+Si `just` n'est pas disponible, utiliser :
+```
+uv run ruff check src/
+uv run ruff format --check src/
+uv run mypy src/
+```
+
+- PASS : zéro erreur/avertissement.
+- FAIL : afficher la sortie de l'outil telle quelle, puis proposer la correction automatique avec `just format` (ruff) ou afficher les erreurs mypy pour résolution manuelle.
+
+---
+
+## 5. Qualité du code — SQL
+
+Commande : `just dbt-lint` ou `uv run sqlfluff lint src/transformation/dbt_paris_event_analyzer/ --dialect duckdb`.
+
+- PASS : zéro violation.
+- FAIL : afficher les violations. Proposer la correction automatique avec `just dbt-lint-fix`.
+
+---
+
+## 6. Hooks pre-commit
+
+Commande : `uv run pre-commit run --all-files`.
+
+Valide les espaces en fin de ligne, EOF, syntaxe YAML/TOML, format des commits conventionnels (le hook commit-msg n'est déclenché qu'au commit — l'ignorer ici), ruff, mypy et sqlfluff.
+
+- PASS : tous les hooks sont verts.
+- FAIL : afficher la sortie des hooks et proposer de laisser pre-commit corriger ce qu'il peut (`pre-commit run --all-files` une seconde fois après les hooks auto-correctifs).
+
+---
+
+## 7. Nombre d'appels logger
+
+Commande : `grep -rn "logger\." src/ --include="*.py" | wc -l`
+
+Le projet impose **exactement 12 appels logger** dans tous les fichiers Python source (contrainte CI documentée dans CLAUDE.md).
+
+- PASS : comptage == 12.
+- FAIL : indiquer le comptage réel et lister les fichiers concernés.
+
+---
+
+## 8. Checklist PR
+
+Inspecter le diff par rapport à la branche de base (`git diff origin/lille...HEAD --stat`).
+
+Vérifier et reporter chaque point :
+
+| Élément | Vérification |
+|---------|--------------|
+| Commits significatifs | Au moins 1 commit au-delà de la base |
+| Pas d'artefacts de debug | Aucun `print()`, `breakpoint()`, `pdb`, `ipdb`, `import pdb` dans les fichiers `.py` |
+| Pas de secrets | Aucun mot de passe, token ou clé API en dur (patterns : `password\s*=\s*["']`, `token\s*=\s*["']`, `api_key\s*=\s*["']`) |
+| Docs à jour | Si `src/` a changé, vérifier si `README.md` ou `CLAUDE.md` nécessitent une mise à jour — signaler sans modifier |
+| `.env` non commité | `.env` ne doit pas apparaître dans `git diff --name-only origin/lille...HEAD` |
+| Version `pyproject.toml` | S'il s'agit d'un commit de release, rappeler de bumper la version avec `cz bump` |
+
+---
+
+## 9. Rapport de synthèse
+
+Après toutes les vérifications, afficher un tableau de synthèse :
+
+```
+┌─────────────────────────────────┬────────┐
+│ Vérification                    │ Statut │
+├─────────────────────────────────┼────────┤
+│ Nommage de branche              │ PASS   │
+│ Messages de commit              │ PASS   │
+│ Changements non commités        │ PASS   │
+│ Lint Python (ruff + mypy)       │ FAIL   │
+│ Lint SQL (sqlfluff)             │ PASS   │
+│ Hooks pre-commit                │ FAIL   │
+│ Comptage appels logger          │ PASS   │
+│ Checklist PR                    │ PASS   │
+└─────────────────────────────────┴────────┘
+
+Problèmes à corriger avant d'ouvrir une PR :
+  [1] ruff: E501 ligne trop longue — src/ingestion/fetch.py:42
+  [2] pre-commit: espace en fin de ligne — src/transformation/dbt_paris_event_analyzer/models/silver/events.sql
+```
+
+Conclure par :
+- "Prêt à ouvrir une PR." (tous les checks PASS)
+- "Corrige les N problème(s) ci-dessus, puis relance /check-contribution." (au moins un FAIL)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,3 +118,78 @@ src/exposition/         → Streamlit web app
 ## CI/CD
 
 `.github/workflows/lille.yml` runs pre-commit hooks via `prek` on pull requests to the `lille` branch.
+
+## Data Exploration Workflow
+
+A reproducible workflow to inspect the warehouse and answer business questions with Claude Code — no plugin required.
+
+### Prerequisites
+
+```bash
+uv sync --frozen --all-groups   # Install dependencies
+uv run just comp-start          # Start MinIO (Docker)
+uv run just ingest              # Fetch today's events from Paris Open Data
+uv run just dbt-run             # Build bronze/silver/gold tables in DuckDB
+```
+
+### Entry points
+
+| Goal | Command |
+|------|---------|
+| Interactive SQL queries | `uv run just duckdb-ui` — opens the DuckDB UI on `warehouse/prod.duckdb` |
+| Browse the model DAG + column docs | `uv run just dbt-catalog` — serves dbt docs on port 3000 |
+| Explore via the app | `uv run just expose` — Streamlit UI with tag/price/accessibility filters |
+| Quick CLI query | `duckdb warehouse/prod.duckdb "SELECT ..."` |
+
+### Key tables
+
+Start from the gold layer; go deeper into silver only if you need raw fields.
+
+| Table | Schema | What it contains |
+|-------|--------|-----------------|
+| `today_events` | gold | Events with at least one occurrence today |
+| `nb_events_by_tags` | gold | Tag frequency — good entry point for category analysis |
+| `handicap_friendly_events` | gold | Events accessible to people with disabilities |
+| `up_to_date_events` | silver | All non-outdated events, fully enriched (coordinates, accessibility struct, parsed schedule) |
+| `agenda` | silver | Parsed occurrence slots — use when querying schedules |
+| `filtered_rows` | silver | Cleaned raw columns (spatial extraction, HTML stripping) |
+| `raw_events` | bronze | All 75 raw columns straight from the parquet file |
+
+### Useful starter queries
+
+```sql
+-- How many events are available today?
+SELECT count(*) FROM gold.today_events;
+
+-- Top 10 tags by event count
+SELECT qfap_tags_distinct, nb_events
+FROM gold.nb_events_by_tags
+LIMIT 10;
+
+-- Free events happening today with an address
+SELECT title, full_address, prochains_creneaux
+FROM gold.today_events
+WHERE price_type = 'Gratuit'
+  AND full_address IS NOT NULL
+ORDER BY rank DESC
+LIMIT 20;
+
+-- Accessible events with coordinates (for a map)
+SELECT title, latitude, longitude, handicap_friendly_details
+FROM gold.handicap_friendly_events
+WHERE latitude IS NOT NULL
+LIMIT 50;
+
+-- Schema introspection: list all columns of a table
+DESCRIBE silver.up_to_date_events;
+```
+
+### Asking Claude Code to explore the data
+
+With the warehouse populated, you can delegate exploration directly to Claude Code:
+
+- *"Combien d'événements gratuits ont lieu cette semaine dans le 11e ?"*
+- *"Quels sont les tags les plus fréquents pour les événements pour enfants ?"*
+- *"Montre-moi les 5 événements les mieux classés avec une adresse complète."*
+
+Claude will run `duckdb warehouse/prod.duckdb "..."` queries against the local file — no external connection needed.


### PR DESCRIPTION
## 🎯 Contexte / Pourquoi

Closes #21

Les contributeurs n'avaient pas de point d'entrée guidé pour explorer le warehouse local avec Claude Code. Cette documentation comble ce manque en décrivant un parcours d'exploration reproductible, orienté usage, sans plugin obligatoire.

## 🔧 Ce qui a changé / Comment

Ajout d'une section **Data Exploration Workflow** dans `CLAUDE.md` (chargé automatiquement par Claude Code) :

- Prérequis et commandes de démarrage (`comp-start` → `ingest` → `dbt-run`)
- Tableau des 4 points d'entrée selon l'objectif (DuckDB UI, dbt catalog, Streamlit, CLI)
- Tableau des 7 tables clés (bronze/silver/gold) avec leur rôle
- 5 requêtes SQL de démarrage prêtes à l'emploi
- Section "Demander à Claude Code d'explorer" avec exemples de prompts

## ✅ Comment tester

1. `uv run just ingest && uv run just dbt-run`
2. Lancer Claude Code dans ce repo
3. Demander : *"Quels sont les 10 tags les plus fréquents ?"* — Claude doit exécuter la requête SQL correspondante sur `warehouse/prod.duckdb` sans configuration supplémentaire

🤖 Generated with [Claude Code](https://claude.com/claude-code)