### PR TITLE
feat: add .env.example and document environment contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# MinIO credentials (used by docker-compose, ingestion, and dbt profiles)
+# MINIO_ROOT_USER — minimum 3 characters
+DBT_ENV_SECRET_MINIO_ACCESS_KEY="minioadmin"
+# MINIO_ROOT_PASSWORD — minimum 8 characters
+DBT_ENV_SECRET_MINIO_SECRET_KEY="minioadmin123"
+
+# dbt paths (required — the project uses non-default locations)
+DBT_PROFILES_DIR="./src/transformation/dbt_paris_event_analyzer/profiles/"
+DBT_PROJECT_DIR="./src/transformation/dbt_paris_event_analyzer/"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,14 +65,20 @@ uv run just duckdb-ui         # Run dbt models and start DuckDB UI
 
 ### Environment Variables
 
-Create a `.env` file at the project root:
+Copy the template and adjust values if needed:
 
 ```bash
-DBT_ENV_SECRET_MINIO_ACCESS_KEY="<username, 3+ chars>"
-DBT_ENV_SECRET_MINIO_SECRET_KEY="<password, 8+ chars>"
-DBT_PROFILES_DIR="./src/transformation/dbt_paris_event_analyzer/profiles/"
-DBT_PROJECT_DIR="./src/transformation/dbt_paris_event_analyzer/"
+cp .env.example .env
 ```
+
+| Variable | Required | Constraint | Used by |
+|----------|----------|------------|---------|
+| `DBT_ENV_SECRET_MINIO_ACCESS_KEY` | Yes | min 3 chars | docker-compose, ingestion, dbt profiles |
+| `DBT_ENV_SECRET_MINIO_SECRET_KEY` | Yes | min 8 chars | docker-compose, ingestion, dbt profiles |
+| `DBT_PROFILES_DIR` | Yes | path | dbt-core (non-default location) |
+| `DBT_PROJECT_DIR` | Yes | path | dbt-core (non-default location) |
+
+See `.env.example` for safe default values.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -142,17 +142,15 @@ uv pip install -e .
 > [!IMPORTANT]
 > Avant de lancer le projet, assurez-vous que :
 > - Le `docker daemon` est en cours d'exécution (Docker Desktop doit être lancé)
-> - Vous avez configuré les variables d'environnement nécessaires dans le fichier `.env` à la racine du projet comme suit :
+> - Vous avez configuré les variables d'environnement en copiant le template :
 >   ```bash
->   DBT_ENV_SECRET_MINIO_ACCESS_KEY="<YOUR_ACCESS_KEY>"
->   DBT_ENV_SECRET_MINIO_SECRET_KEY="<YOUR_SECRET_KEY>"
->   DBT_PROFILES_DIR="./src/transformation/dbt_paris_event_analyzer/profiles/"
->   DBT_PROJECT_DIR="./src/transformation/dbt_paris_event_analyzer/"
+>   cp .env.example .env
 >   ```
->   Les identifiants sont à choisir librement avec les règles suivantes :
+>   Les identifiants MinIO sont à choisir librement avec les règles suivantes :
 >  - `DBT_ENV_SECRET_MINIO_ACCESS_KEY` : au moins 3 caractères, correspond à votre nom d'utilisateur
 >  - `DBT_ENV_SECRET_MINIO_SECRET_KEY` : au moins 8 caractères, correspond à votre mot de passe
 >
+>   Voir `.env.example` pour le détail de toutes les variables et leurs valeurs par défaut.
 
 3. Déployer les services nécessaires
 ```bash


### PR DESCRIPTION
Closes #8

## Summary
- Add `.env.example` with all 4 required variables and safe default values
- Update `CLAUDE.md` environment section with a contract table (variable, constraint, usage)
- Simplify `README.md` setup instructions to point to `.env.example`

## Test plan
- [ ] `cp .env.example .env` then run `uv run just comp-start` — MinIO should start correctly
- [ ] `uv run just dbt-debug` — dbt should find its profiles and project directory
- [ ] Verify `.env.example` values are consistent with `docker-compose.yml` and `profiles.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)